### PR TITLE
Added cloud functions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ $ open your-project.xcworkspace
     - Select **Sign In** and select Facebook to begin.
 
 
-## Cloud Functions
+## Requirements
 
-The required Cloud Functions can be found at [FriendlyPix Web Repository](https://github.com/firebase/friendlypix-web/tree/master/functions).
+The mobile FriendlyPix app need the Cloud Functions, the Realtime Database rules and the Cloud Storage rules to be deployed to work properly. You can find instructions at [FriendlyPix Web Repository](https://github.com/firebase/friendlypix-web/blob/master/README.md#mobile-apps).
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ $ open your-project.xcworkspace
     - Select **Sign In** and select Facebook to begin.
 
 
+## Cloud Functions
+
+The required Cloud Functions can be found at [FriendlyPix Web Repository](https://github.com/firebase/friendlypix-web/tree/master/functions).
+
+
 ## Contributing
 
 We'd love that you contribute to the project. Before doing so please read our [Contributor guide](../CONTRIBUTING.md).


### PR DESCRIPTION
There is no documentation pointing to the required Cloud Functions at all.

Developers trying to run mobile examples only (android and/or iOS) won't be able to make it work as expected.

Also, even on the web example, there is no instruction regarding publishing the functions.

This PR adds a link to the Cloud Functions into the README.