### PR TITLE
Fixes a bug which would crash when running in an iPad

### DIFF
--- a/FriendlyPix/FPAccountViewController.swift
+++ b/FriendlyPix/FPAccountViewController.swift
@@ -238,18 +238,22 @@ class FPAccountViewController: MDCCollectionViewController {
     }
   }
 
-  @IBAction func didTapMore(_ sender: Any) {
+  @IBAction func didTapMore(_ sender: UIBarButtonItem) {
+
     let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-    alert.addAction(UIAlertAction(title: "Sign out", style: .default , handler:{ (UIAlertAction)in
-      self.didSelectSignOut()
-    }))
+    alert.popoverPresentationController?.barButtonItem = sender
 
-    alert.addAction(UIAlertAction(title: "Delete account", style: .destructive , handler:{ _ in
+    alert.addAction(UIAlertAction(title: "Sign out", style: .default) { _ in
+      self.didSelectSignOut()
+    })
+
+    alert.addAction(UIAlertAction(title: "Delete account", style: .destructive) { _ in
       self.deleteAccount()
-    }))
+    })
 
     alert.addAction(UIAlertAction(title: "Cancel", style: .cancel , handler: nil))
+
     self.present(alert, animated: true, completion: nil)
   }
 


### PR DESCRIPTION
This PR fixes a bug which would cause the app to crash when running on iPads (or iPad Simulator), after tapping the "more" button, on the account page.

It was caused by `UIAlertController`, which requires it's `popoverPresentationController` property to have either a `barButtonItem` or a `sourceRect` and a `sourceView` populated, when using `.actionSheet` style on iPads.